### PR TITLE
Remove old @StanfordCrypto delegate wallets.

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -1168,13 +1168,6 @@
       "handle": "_Bliiitz"
     }
   },
-  "0xEFF506a32B55D5c19847c1a4F8510c00280c27E5": {
-    "twitter": {
-      "timestamp": 1609882339141,
-      "tweetID": "1346570215342047232",
-      "handle": "StanfordCrypto"
-    }
-  },
   "0x159DDA55aB7b74C13Be4e1616c276d87B387D630": {
     "twitter": {
       "timestamp": 1609957714678,
@@ -10777,13 +10770,6 @@
       "timestamp": 1629317992542,
       "tweetID": "1428089253842628615",
       "handle": "tangfeng0x"
-    }
-  },
-  "0x347120F6d2e3142cacEd44Ad008708D80a4F9420": {
-    "twitter": {
-      "timestamp": 1629333228804,
-      "tweetID": "1428153142626160644",
-      "handle": "StanfordCrypto"
     }
   },
   "0x2aE9fF8891d81519cA55250a5888aa3f14aDa2Ed": {


### PR DESCRIPTION
Remove 0xEFF506a32B55D5c19847c1a4F8510c00280c27E5 and 0x347120F6d2e3142cacEd44Ad008708D80a4F9420's association from Stanford Blockchain Club. Both verification tweets were also deleted.